### PR TITLE
Fix default min length

### DIFF
--- a/cpp/include/tensorrt_llm/layers/defaultDecodingParams.h
+++ b/cpp/include/tensorrt_llm/layers/defaultDecodingParams.h
@@ -52,7 +52,7 @@ public:
 
     [[nodiscard]] __host__ __device__ static constexpr runtime::SizeType32 getMinLength()
     {
-        return 1;
+        return 0;
     }
 
     [[nodiscard]] __host__ __device__ static constexpr uint64_t getSeed()


### PR DESCRIPTION
When passing 1 to the minimum length I expect at least 1 NOT eof token.

But since 1 is the default value `minLengths` tensor is [nullptr](https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/layers/penaltyLayer.cpp#L323) and penalty does't work.